### PR TITLE
Updating to latest lucky_sec_tester. Adding a spec to test one of the API actions

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -94,7 +94,7 @@ shards:
 
   sec_tester:
     git: https://github.com/neuralegion/sec_tester.git
-    version: 1.2.2
+    version: 1.2.3
 
   selenium:
     git: https://github.com/matthewmcgarvey/selenium.cr.git

--- a/shard.lock
+++ b/shard.lock
@@ -74,7 +74,7 @@ shards:
 
   lucky_sec_tester:
     git: https://github.com/luckyframework/lucky_sec_tester.git
-    version: 0.1.0+git.commit.f12059a8f1f83f29c77f509b89c035c2b6d8fa7f
+    version: 0.1.0+git.commit.7612434c877129eef4631522bc8f397c7366c5ad
 
   lucky_task:
     git: https://github.com/luckyframework/lucky_task.git

--- a/spec/flows/security_spec.cr
+++ b/spec/flows/security_spec.cr
@@ -94,13 +94,13 @@ describe "SecTester" do
       scanner.run_check(
         scan_name: "ref: #{ENV["GITHUB_REF"]?} commit: #{ENV["GITHUB_SHA"]?} run id: #{ENV["GITHUB_RUN_ID"]?}",
         tests: [
-          "sqli", # Testing for SQL Injection issues (https://docs.neuralegion.com/docs/sql-injection)
-          "jwt",  # Testing JWT usage (https://docs.neuralegion.com/docs/broken-jwt-authentication)
+          "sqli",            # Testing for SQL Injection issues (https://docs.neuralegion.com/docs/sql-injection)
+          "jwt",             # Testing JWT usage (https://docs.neuralegion.com/docs/broken-jwt-authentication)
           "cookie_security", # Making sure the cookies are safe and use `Secure` and `HttpOnly`
-          "xss", # Checking for Cross Site Scripting attacks (https://docs.neuralegion.com/docs/reflective-cross-site-scripting-rxss)
-          "dom_xss", # Checking for DOM based XSS (Client side attack)
-          "ssrf", # Checking for SSRF (https://docs.neuralegion.com/docs/server-side-request-forgery-ssrf)
-          "proto_pollution", # Checking for proto pollution based vulnerabilities (https://docs.neuralegion.com/docs/prototype-pollution) 
+          "xss",             # Checking for Cross Site Scripting attacks (https://docs.neuralegion.com/docs/reflective-cross-site-scripting-rxss)
+          "dom_xss",         # Checking for DOM based XSS (Client side attack)
+          "ssrf",            # Checking for SSRF (https://docs.neuralegion.com/docs/server-side-request-forgery-ssrf)
+          "proto_pollution", # Checking for proto pollution based vulnerabilities (https://docs.neuralegion.com/docs/prototype-pollution)
         ],
         target: target
       )

--- a/spec/flows/security_spec.cr
+++ b/spec/flows/security_spec.cr
@@ -94,8 +94,13 @@ describe "SecTester" do
       scanner.run_check(
         scan_name: "ref: #{ENV["GITHUB_REF"]?} commit: #{ENV["GITHUB_SHA"]?} run id: #{ENV["GITHUB_RUN_ID"]?}",
         tests: [
-          "sqli",
-          "jwt",
+          "sqli", # Testing for SQL Injection issues (https://docs.neuralegion.com/docs/sql-injection)
+          "jwt",  # Testing JWT usage (https://docs.neuralegion.com/docs/broken-jwt-authentication)
+          "cookie_security", # Making sure the cookies are safe and use `Secure` and `HttpOnly`
+          "xss", # Checking for Cross Site Scripting attacks (https://docs.neuralegion.com/docs/reflective-cross-site-scripting-rxss)
+          "dom_xss", # Checking for DOM based XSS (Client side attack)
+          "ssrf", # Checking for SSRF (https://docs.neuralegion.com/docs/server-side-request-forgery-ssrf)
+          "proto_pollution", # Checking for proto pollution based vulnerabilities (https://docs.neuralegion.com/docs/prototype-pollution) 
         ],
         target: target
       )

--- a/spec/flows/security_spec.cr
+++ b/spec/flows/security_spec.cr
@@ -84,6 +84,23 @@ describe "SecTester" do
       )
     end
   end
+
+  it "tests API actions" do
+    with_cleanup(scanner) do
+      api_headers = HTTP::Headers{"Content-Type" => "application/json", "Accept" => "application/json"}
+      target = scanner.build_target(Api::SignIns::Create, headers: api_headers) do |t|
+        t.body = {"user" => {"email" => "aa%40aa.com", "password" => "123456789"}}.to_json
+      end
+      scanner.run_check(
+        scan_name: "ref: #{ENV["GITHUB_REF"]?} commit: #{ENV["GITHUB_SHA"]?} run id: #{ENV["GITHUB_RUN_ID"]?}",
+        tests: [
+          "sqli",
+          "jwt"
+        ],
+        target: target
+      )
+    end
+  end
 end
 
 private def scanner

--- a/spec/flows/security_spec.cr
+++ b/spec/flows/security_spec.cr
@@ -95,7 +95,7 @@ describe "SecTester" do
         scan_name: "ref: #{ENV["GITHUB_REF"]?} commit: #{ENV["GITHUB_SHA"]?} run id: #{ENV["GITHUB_RUN_ID"]?}",
         tests: [
           "sqli",
-          "jwt"
+          "jwt",
         ],
         target: target
       )


### PR DESCRIPTION
With this latest LuckySecTester, we can now override the headers to tell Lucky we're making API requests.

I'm actually not too sure on what this spec should really look like. My guess is since we use JWT out of the box, then we should probably test jwt, and the sqli on sign in. I'd like this test to ensure that you can't craft your own jwt and/or brute force your way in to the API to get back a valid token. Feel free to change the spec if you have some better ideas on how we can test one of the API actions. I think as long as we can get at least 1 tested, that'll be good enough to start, then we can work on adding in the others later.